### PR TITLE
Switch to using Delegates

### DIFF
--- a/Assets/Scenes/FFPlay.unity
+++ b/Assets/Scenes/FFPlay.unity
@@ -295,10 +295,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 744513910}
+  - component: {fileID: 744513913}
   - component: {fileID: 744513909}
   - component: {fileID: 744513911}
   - component: {fileID: 744513912}
-  - component: {fileID: 744513913}
   m_Layer: 0
   m_Name: FFPlay
   m_TagString: Untagged
@@ -350,8 +350,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pts: 0
-  renderMesh: {fileID: 1264032661}
-  materialIndex: -1
 --- !u!114 &744513912
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -365,7 +363,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pts: 0
-  source: {fileID: 1264032665}
+  bufferDelay: 1
 --- !u!114 &744513913
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -509,6 +507,7 @@ GameObject:
   - component: {fileID: 1264032663}
   - component: {fileID: 1264032662}
   - component: {fileID: 1264032661}
+  - component: {fileID: 1264032666}
   - component: {fileID: 1264032664}
   - component: {fileID: 1264032665}
   m_Layer: 0
@@ -691,8 +690,26 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b2c04debbdd7eaf4a8c0abbb01bd3742, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  audioPlayer: {fileID: 744513912}
   audioSource: {fileID: 0}
-  bufferDelay: 1
+  lockVolume: 0
+  volumeControlsMute: 0
+--- !u!114 &1264032666
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1264032659}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: caf3d4a9062b4bd8b88773a3e6adc754, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  texturePlayer: {fileID: 744513911}
+  materialIndex: -1
+  textureProperty: _EmissionMap
+  updateGIRealtime: 1
 --- !u!850595691 &1495372973
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -1020,5 +1037,5 @@ SceneRoots:
   - {fileID: 963194228}
   - {fileID: 1601762792}
   - {fileID: 1961929551}
-  - {fileID: 1264032663}
   - {fileID: 744513910}
+  - {fileID: 1264032663}

--- a/Assets/Scripts/FFTest2.cs
+++ b/Assets/Scripts/FFTest2.cs
@@ -24,7 +24,7 @@ public class FFTest2 : MonoBehaviour
     private void Start()
     {
         id = GetInstanceID();
-        ffmpeg.texturePlayer.OnDisplay = OnDisplay;
+        ffmpeg.texturePlayer.OnDisplay += OnDisplay;
         Play();
     }
 

--- a/Packages/FFmpeg.Unity/Runtime/BufferAudioSource.cs
+++ b/Packages/FFmpeg.Unity/Runtime/BufferAudioSource.cs
@@ -36,8 +36,13 @@ public class BufferAudioSource : MonoBehaviour
     private int clipchannels;
     private int clipfrequency;
 
-    private void Awake()
+    private void Start()
     {
+        if (!audioPlayer) audioPlayer = GetComponentInParent<FFmpeg.Unity.FFAudioPlayer>(true);
+        if (!audioPlayer)
+        {
+            Debug.LogWarning("No FFAudioPlayer found.");
+        }
         audioSource = GetComponent<AudioSource>();
         audioPlayer.OnPause += Pause;
         audioPlayer.OnResume += Resume;

--- a/Packages/FFmpeg.Unity/Runtime/BufferAudioSource.cs
+++ b/Packages/FFmpeg.Unity/Runtime/BufferAudioSource.cs
@@ -24,9 +24,11 @@ public class BufferAudioSource : MonoBehaviour
     private int lastTimeSamples = 0;
     private int maxEmptyReads = 0;
     private AudioClip clip = null;
-    [HideInInspector]
-    public AudioSource audioSource;
-    public float bufferDelay = 1f;
+    public FFmpeg.Unity.FFAudioPlayer audioPlayer;
+    [HideInInspector] public AudioSource audioSource;
+
+    [SerializeField] private bool lockVolume;
+    [SerializeField] private bool volumeControlsMute;
 
     private float[] spectrum = new float[1024];
 
@@ -37,6 +39,41 @@ public class BufferAudioSource : MonoBehaviour
     private void Awake()
     {
         audioSource = GetComponent<AudioSource>();
+        audioPlayer.OnPause += Pause;
+        audioPlayer.OnResume += Resume;
+        audioPlayer.OnSeek += Seek;
+        audioPlayer.OnVolumeChange += SetVolume;
+        audioPlayer.AddQueue += AddQueue;
+    }
+
+    private void OnDestroy()
+    {
+        audioPlayer.OnPause -= Pause;
+        audioPlayer.OnResume -= Resume;
+        audioPlayer.OnSeek -= Seek;
+        audioPlayer.OnVolumeChange -= SetVolume;
+        audioPlayer.AddQueue -= AddQueue;
+    }
+
+    public void Pause()
+    {
+        audioSource.Pause();
+    }
+
+    public void Resume()
+    {
+        audioSource.UnPause();
+    }
+
+    public void Seek()
+    {
+        Stop();
+    }
+
+    private void SetVolume(float volume)
+    {
+        if (!lockVolume) audioSource.volume = volume;
+        if (volumeControlsMute) audioSource.mute = volume == 0;
     }
 
     private void Update()
@@ -113,7 +150,7 @@ public class BufferAudioSource : MonoBehaviour
         bool newClip = false;
         if (clip == null || clipchannels != channels || clipfrequency != frequency)
         {
-            maxEmptyReads = (int)(frequency * channels * bufferDelay);
+            maxEmptyReads = (int)(frequency * channels * audioPlayer.bufferDelay);
             newClip = true;
         }
         AddRingBuffer(pcm);
@@ -135,7 +172,7 @@ public class BufferAudioSource : MonoBehaviour
         RingBufferPosition = 0;
         PlaybackPosition = 0;
         stopTime = RingBufferPosition + pcm.Length;
-        stopTimer = bufferDelay;
+        stopTimer = audioPlayer.bufferDelay;
         AddRingBuffer(pcm);
         audioSource.Play();
     }

--- a/Packages/FFmpeg.Unity/Runtime/DisplayOnMeshRenderer.cs
+++ b/Packages/FFmpeg.Unity/Runtime/DisplayOnMeshRenderer.cs
@@ -1,0 +1,46 @@
+using System;
+using UnityEngine;
+using UnityEngine.Serialization;
+
+namespace FFmpeg.Unity
+{
+    [RequireComponent(typeof(MeshRenderer))]
+    public class DisplayOnMeshRenderer : MonoBehaviour
+    {
+        public FFTexturePlayer texturePlayer;
+        private MeshRenderer renderMesh;
+        public int materialIndex = -1;
+        public string textureProperty = "_EmissionMap";
+        private MaterialPropertyBlock propertyBlock;
+        public bool updateGIRealtime = true;
+
+        private void Start()
+        {
+            if (!texturePlayer) texturePlayer = GetComponentInParent<FFTexturePlayer>(true);
+            if (!texturePlayer)
+            {
+                Debug.LogWarning("No FFTexturePlayer found.");
+            }
+            propertyBlock = new MaterialPropertyBlock();
+            renderMesh = GetComponent<MeshRenderer>();
+            texturePlayer.OnDisplay += Display;
+        }
+
+        private void OnDestroy()
+        {
+            texturePlayer.OnDisplay -= Display;
+        }
+
+        public void Display(Texture2D texture)
+        {
+            if (texture != null) propertyBlock.SetTexture(textureProperty, texture);
+
+            if (renderMesh != null)
+            {
+                if (materialIndex == -1) renderMesh.SetPropertyBlock(propertyBlock);
+                else renderMesh.SetPropertyBlock(propertyBlock, materialIndex);
+                if (updateGIRealtime) renderMesh.UpdateGIMaterials();
+            }
+        }
+    }
+}

--- a/Packages/FFmpeg.Unity/Runtime/DisplayOnMeshRenderer.cs.meta
+++ b/Packages/FFmpeg.Unity/Runtime/DisplayOnMeshRenderer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: caf3d4a9062b4bd8b88773a3e6adc754
+timeCreated: 1734404737

--- a/Packages/FFmpeg.Unity/Runtime/FFAudioPlayer.cs
+++ b/Packages/FFmpeg.Unity/Runtime/FFAudioPlayer.cs
@@ -18,11 +18,11 @@ namespace FFmpeg.Unity
 
         public delegate void AddQueueDelegate(float[] pcm, int channels, int frequency);
 
-        public OnResumeDelegate OnResume;
-        public OnPauseDelegate OnPause;
-        public OnSeekDelegate OnSeek;
-        public OnVolumeChangeDelegate OnVolumeChange;
-        public AddQueueDelegate AddQueue;
+        public event OnResumeDelegate OnResume;
+        public event OnPauseDelegate OnPause;
+        public event OnSeekDelegate OnSeek;
+        public event OnVolumeChangeDelegate OnVolumeChange;
+        public event AddQueueDelegate AddQueue;
 
         public long pts;
         public float bufferDelay = 1f;
@@ -30,7 +30,7 @@ namespace FFmpeg.Unity
         private int channels;
         private int frequency;
         private AVSampleFormat sampleFormat;
-        private List<float> pcm = new List<float>();
+        private readonly List<float> pcm = new List<float>();
 
         public void Init(int frequency, int channels, AVSampleFormat sampleFormat)
         {

--- a/Packages/FFmpeg.Unity/Runtime/FFPlayUnity.cs
+++ b/Packages/FFmpeg.Unity/Runtime/FFPlayUnity.cs
@@ -12,10 +12,21 @@ namespace FFmpeg.Unity
 
         private Thread thread;
 
-        public event Action OnEndReached;
-        public event Action OnVideoEndReached;
-        public event Action OnAudioEndReached;
-        public event Action OnError;
+        public delegate void OnEndReachedDelegate();
+
+        public delegate void OnVideoEndReachedDelegate();
+
+        public delegate void OnAudioEndReachedDelegate();
+
+        public delegate void OnErrorDelegate();
+
+        public delegate void OnMediaReadyDelegate();
+
+        public OnEndReachedDelegate OnEndReached;
+        public OnVideoEndReachedDelegate OnVideoEndReached;
+        public OnAudioEndReachedDelegate OnAudioEndReached;
+        public OnErrorDelegate OnError;
+        public OnMediaReadyDelegate OnMediaReady;
 
         public double videoOffset = 0d;
         public double audioOffset = 0d;
@@ -85,6 +96,7 @@ namespace FFmpeg.Unity
             }
             else
             {
+                OnMediaReady?.Invoke();
                 audioPlayer.Resume();
                 RunThread();
                 IsPlaying = true;
@@ -187,10 +199,11 @@ namespace FFmpeg.Unity
                         videoTimings.Update(VideoTime);
                         texturePlayer.PlayPacket(videoTimings.GetFrame(250));
                     }
+
                     if (audioTimings != null)
                     {
                         audioTimings.Update(AudioTime);
-                        audioPlayer.PlayPackets(audioTimings.GetFrames(audioPlayer.source.bufferDelay, 500));
+                        audioPlayer.PlayPackets(audioTimings.GetFrames(audioPlayer.bufferDelay, 500));
                     }
                 }
                 catch (Exception e)
@@ -199,6 +212,7 @@ namespace FFmpeg.Unity
                     break;
                 }
             }
+
             Debug.Log("ThreadUpdate Done");
         }
 

--- a/Packages/FFmpeg.Unity/Runtime/FFPlayUnity.cs
+++ b/Packages/FFmpeg.Unity/Runtime/FFPlayUnity.cs
@@ -22,11 +22,11 @@ namespace FFmpeg.Unity
 
         public delegate void OnMediaReadyDelegate();
 
-        public OnEndReachedDelegate OnEndReached;
-        public OnVideoEndReachedDelegate OnVideoEndReached;
-        public OnAudioEndReachedDelegate OnAudioEndReached;
-        public OnErrorDelegate OnError;
-        public OnMediaReadyDelegate OnMediaReady;
+        public event OnEndReachedDelegate OnEndReached;
+        public event OnVideoEndReachedDelegate OnVideoEndReached;
+        public event OnAudioEndReachedDelegate OnAudioEndReached;
+        public event OnErrorDelegate OnError;
+        public event OnMediaReadyDelegate OnMediaReady;
 
         public double videoOffset = 0d;
         public double audioOffset = 0d;

--- a/Packages/FFmpeg.Unity/package.json
+++ b/Packages/FFmpeg.Unity/package.json
@@ -1,6 +1,6 @@
 {
     "name": "net.virtualwebsite.ffmpegunity",
     "displayName": "FFmpeg.Unity",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Video player system for Unity using FFmpeg."
 }


### PR DESCRIPTION
- This enables baseline support for using multiple BufferAudioSource'a for the same AudioPlayer instance, ie duplicate speakers.
- This also necessitates moving the bufferDelay to the AudioPlayer which is fine because all audio sources should consider the same buffer delay when pulling from the same AudioPlayer anyways.
- Made TexturePlayer also use delegate for display and made a new DisplayOnMeshRenderer script for handling that specific part of the code. This simplifies FFTexturePlayer to just being an output for the texture rather than having any particular component dependencies.
- Updates package version to 0.3.0