### PR TITLE
Add toggle to enable flipping the texture during texture write

### DIFF
--- a/Packages/FFmpeg.Unity/Runtime/FFPlayUnity.cs
+++ b/Packages/FFmpeg.Unity/Runtime/FFPlayUnity.cs
@@ -233,6 +233,7 @@ namespace FFmpeg.Unity
 
         private void OnDestroy()
         {
+            StopThread();
             videoTimings?.Dispose();
             videoTimings = null;
             audioTimings?.Dispose();
@@ -274,7 +275,6 @@ namespace FFmpeg.Unity
         public void OnDisable()
         {
             IsPaused = true;
-            StopThread();
             OnDestroy();
         }
     }

--- a/Packages/FFmpeg.Unity/Runtime/FFTexturePlayer.cs
+++ b/Packages/FFmpeg.Unity/Runtime/FFTexturePlayer.cs
@@ -19,7 +19,9 @@ namespace FFmpeg.Unity
         private byte[] frameData = new byte[0];
         private byte[] backbuffer = new byte[0];
         private readonly Mutex mutex = new Mutex();
+        [Tooltip("Force output texture size to specified width. Set to 0 to use source width.")]
         public int imageWidth = 1280;
+        [Tooltip("Force output texture size to specified height. Set to 0 to use source height.")]
         public int imageHeight = 720;
         [Tooltip("Flags whether the texture data should be flipped on the Y axis or not. Minor performance cost when enabled.")]
         public bool flipTexture = true;
@@ -31,8 +33,8 @@ namespace FFmpeg.Unity
 
         public void PlayPacket(AVFrame frame)
         {
-            int width = imageWidth;
-            int height = imageHeight;
+            int width = imageWidth > 0 ? imageWidth : frame.width;
+            int height = imageHeight > 0 ? imageHeight : frame.height;
             int len = width * height * 3;
             if (backbuffer.Length != len)
                 backbuffer = new byte[len];

--- a/Packages/FFmpeg.Unity/Runtime/FFTexturePlayer.cs
+++ b/Packages/FFmpeg.Unity/Runtime/FFTexturePlayer.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Threading;
+using Unity.Collections;
+using Unity.Collections.LowLevel.Unsafe;
 using UnityEngine;
 
 namespace FFmpeg.Unity
@@ -9,7 +11,6 @@ namespace FFmpeg.Unity
     {
         public delegate void OnDisplayDelegate(Texture2D texture);
 
-        public long pts;
         public event OnDisplayDelegate OnDisplay;
         private Texture2D image;
         private int frameWidth;
@@ -20,14 +21,16 @@ namespace FFmpeg.Unity
         private readonly Mutex mutex = new Mutex();
         public int imageWidth = 1280;
         public int imageHeight = 720;
+        [Tooltip("Flags whether the texture data should be flipped on the Y axis or not. Minor performance cost when enabled.")]
+        public bool flipTexture = true;
+        private NativeArray<byte> texData;
+        private int pixelStride = 4;
+        
+        [Header("Runtime Data")]
+        public long pts;
 
         public void PlayPacket(AVFrame frame)
         {
-            // int len = frame.width * frame.height * 3;
-            // const int width = 1280;
-            // const int height = 720;
-            // const int width = 640;
-            // const int height = 480;
             int width = imageWidth;
             int height = imageHeight;
             int len = width * height * 3;
@@ -78,27 +81,71 @@ namespace FFmpeg.Unity
             if (image == null)
                 image = new Texture2D(16, 16, TextureFormat.RGB24, false);
             if (image.width != width || image.height != height)
+            {
+                // image presumed to be changed. Cache new image information.
                 image.Reinitialize(width, height);
-            var arr = image.GetRawTextureData<byte>();
-            arr.CopyFrom(data);
+                pixelStride = width * GetBytesPerPixel(image.format);
+                texData = image.GetRawTextureData<byte>();
+            }
+
+            if (!flipTexture) texData.CopyFrom(data);
+            else
+            {
+                unsafe
+                {
+                    fixed (byte* srcPtr = data)
+                    {
+                        byte* dstPtr = (byte*)texData.GetUnsafePtr();
+                        // Copy rows in reverse order
+                        var heightLessOne = height - 1;
+                        for (int y = 0; y < height; y++)
+                        {
+                            byte* srcRow = srcPtr + (y * pixelStride);
+                            byte* dstRow = dstPtr + ((heightLessOne - y) * pixelStride);
+
+                            // Copy the entire row at once
+                            UnsafeUtility.MemCpy(dstRow, srcRow, pixelStride);
+                        }
+                    }
+                }
+            }
+
             image.Apply(false);
         }
 
         #region Utils
 
-        [ThreadStatic]
-        private static byte[] line;
+        // Helper method to determine bytes per pixel
+        private static int GetBytesPerPixel(TextureFormat format)
+        {
+            return format switch
+            {
+                TextureFormat.RGBA32 => 4,
+                TextureFormat.RGB24 => 3,
+                TextureFormat.R8 => 1,
+                TextureFormat.RGBAHalf => 8,
+                TextureFormat.RGBAFloat => 16,
+                TextureFormat.RGHalf => 4,
+                TextureFormat.RGFloat => 8,
+                TextureFormat.RHalf => 2,
+                TextureFormat.RFloat => 4,
+                TextureFormat.ARGB32 => 4,
+                TextureFormat.RGBA4444 => 2,
+                TextureFormat.BGRA32 => 4,
+                _ => 4 // Default to 4 if unknown
+            };
+        }
+
+
+        [ThreadStatic] private static byte[] line;
 
         public static unsafe bool SaveFrame(AVFrame frame, byte[] texture, int width, int height)
         {
-            if (line == null)
-            {
-                line = new byte[4096 * 4096 * 6]; // TODO: is the buffer big enough?
-            }
+            if (line == null) line = new byte[4096 * 4096 * 6]; // TODO: is the buffer big enough?
+            
             if (frame.data[0] == null || frame.format == -1 || texture == null)
-            {
                 return false;
-            }
+            
             using var converter = new VideoFrameConverter(new System.Drawing.Size(frame.width, frame.height), (AVPixelFormat)frame.format, new System.Drawing.Size(width, height), AVPixelFormat.AV_PIX_FMT_RGB24);
             var convFrame = converter.Convert(frame);
             int len = convFrame.width * convFrame.height * 3;


### PR DESCRIPTION
Enabled by default.
Performance impact is averaged 0.4-0.6ms when enabled.
Add support for using the texture source dimensions.

Addendum fix for VideoDecodeThread sometimes not closing out properly when exiting playmode.
OnDestroy should also attempt thread stopping, not just OnDisable.