### PR TITLE
Avoid array allocations when decoding AVFrames

### DIFF
--- a/Packages/FFmpeg.Unity/Runtime/FFAudioPlayer.cs
+++ b/Packages/FFmpeg.Unity/Runtime/FFAudioPlayer.cs
@@ -44,15 +44,15 @@ namespace FFmpeg.Unity
         public void Seek() => OnSeek?.Invoke();
         public void SetVolume(float volume) => OnVolumeChange?.Invoke(volume);
 
-        public void PlayPackets(List<AVFrame> frames)
+        public void PlayPackets(ICollection<AVFrame> frames, int frameCount = -1)
         {
-            if (frames.Count == 0)
-            {
-                return;
-            }
+            if (frames.Count == 0) return;
+            if (frameCount == -1) frameCount = frames.Count;
 
             foreach (var frame in frames)
             {
+                if (frameCount == 0) break;
+                frameCount--;
                 QueuePacket(frame);
             }
         }
@@ -68,6 +68,7 @@ namespace FFmpeg.Unity
                 Debug.LogError("audio buffer size is less than zero");
                 return;
             }
+
             for (int i = 0; i < size / sizeof(float); i++)
                 pcm.Add(0f);
             for (uint ch = 0; ch < channels; ch++)

--- a/Packages/FFmpeg.Unity/Runtime/FFPlayUnity.cs
+++ b/Packages/FFmpeg.Unity/Runtime/FFPlayUnity.cs
@@ -210,6 +210,7 @@ namespace FFmpeg.Unity
             }
         }
 
+        private AVFrame[] frames = new AVFrame[500];
         private void AudioDecodeThreadUpdate()
         {
             while (!IsPaused)
@@ -220,7 +221,8 @@ namespace FFmpeg.Unity
                     if (audioTimings != null)
                     {
                         audioTimings.Update(AudioTime);
-                        audioPlayer.PlayPackets(audioTimings.GetFrames(maxAudioDelta, 500));
+                        int frameCount = audioTimings.GetFramesNonAlloc(maxAudioDelta, ref frames);
+                        audioPlayer.PlayPackets(frames, frameCount);
                     }
                 }
                 catch (Exception e)


### PR DESCRIPTION
Hoist AVFrame list to an array to avoid unnecessary allocations during decoding.
Add NonAlloc methods for decoding and getting frames. 
Update PlayPackets to accept generic collections for Array support.